### PR TITLE
Added use-reducer-async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9527,6 +9527,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-reducer-async": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/use-reducer-async/-/use-reducer-async-2.0.0.tgz",
+      "integrity": "sha512-EuejXO92k4tp2lyR5KwbhxVf5oQ7VIoqDbUa/e8ps1DeE0QA1ApRGbW55FY7EpoVFcgasV5SJJ6VQ3i1zdXD7g=="
+    },
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "react": ">=16.8.0",
-    "react-test-renderer": ">=16.8.0"
+    "use-reducer-async": "^2.0.0"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.8.3",
@@ -81,6 +81,7 @@
     "open-cli": "^5.0.0",
     "prettier": "^1.18.2",
     "react-dom": "^16.12.0",
+    "react-test-renderer": ">=16.8.0",
     "standard-version": "^6.0.1",
     "trash-cli": "^3.0.0",
     "ts-jest": "^25.2.0",

--- a/src/lib/__tests__/contextManager.spec.tsx
+++ b/src/lib/__tests__/contextManager.spec.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { render, fireEvent, getByTestId } from '@testing-library/react'
+import { render, fireEvent, getByTestId, wait } from '@testing-library/react';
 
 import ContextProvider, { initContext } from '../contextManager';
 import { GlobalStore, UnBoundActions, UnBoundScope } from '../types';
@@ -13,10 +13,10 @@ interface Store extends GlobalStore {
 
 interface TestScope extends UnBoundScope<Store> {
   readonly testAction: (_: Store) => (textToChange: string) => Store;
-};
+}
 interface Actions extends UnBoundActions<Store> {
   readonly test: TestScope;
-};
+}
 
 const testContext = initContext<Store, Actions>();
 const newText = 'It worked!';
@@ -29,42 +29,51 @@ const DummyComponent = () => {
     <p>
       <span data-testid="should-change">{store.test.textToChange}</span>
       <span data-testid="not-should-change">{store.test.textToKeep}</span>
-      <button data-testid="button" onClick={() => actions.test.testAction('It worked!')}>
+      <button
+        data-testid="button"
+        onClick={() => actions.test.testAction('It worked!')}
+      >
         Change
       </button>
     </p>
-  )
+  );
+};
+
+const actions: Actions = {
+  test: {
+    testAction: (state: Store) => (textToChange: string) => {
+      return {
+        test: { ...state.test, textToChange }
+      };
+    }
+  }
+};
+
+const store: Store = {
+  test: {
+    textToChange: 'not worked :(',
+    textToKeep: 'not change'
+  }
 };
 
 describe('contextManager', () => {
   describe('ContextProvider', () => {
-    const actions: Actions = {
-      test: {
-        testAction: (state: Store) => (textToChange: string) => ({
-          ...state, test: { ...state.test, textToChange } 
-        })
-      }
-    };
-
-    const store: Store = {
-      test: {
-        textToChange: 'not worked :(',
-        textToKeep: 'not change'
-      }
-    };
-
-    it('should change the context state value when a button is clicked', () => {
+    it('should change the context state value when a button is clicked', async () => {
       const { container } = render(
         <ContextProvider actions={actions} store={store} context={testContext}>
           <DummyComponent />
         </ContextProvider>
       );
-      const shouldChangeElement = getByTestId(container, 'should-change');
-      const notShouldChangeElement = getByTestId(container, 'not-should-change');
+      let shouldChangeElement = getByTestId(container, 'should-change');
+      let notShouldChangeElement = getByTestId(container, 'not-should-change');
       expect(shouldChangeElement.textContent).toBe(store.test.textToChange);
       expect(notShouldChangeElement.textContent).toBe(store.test.textToKeep);
+
       const button = getByTestId(container, 'button');
       fireEvent.click(button);
+
+      await wait(() => getByTestId(container, 'should-change').textContent);
+
       expect(shouldChangeElement.textContent).toBe(newText);
       expect(notShouldChangeElement.textContent).toBe(store.test.textToKeep);
     });

--- a/src/lib/__tests__/utils.spec.ts
+++ b/src/lib/__tests__/utils.spec.ts
@@ -1,51 +1,53 @@
-import { GlobalStore, UnBoundActions } from '../types';
-import { createDispatcher, createReducer, bindScope } from '../utils';
+import { GlobalStore, Modifiers } from '../types';
+import { createDispatcher, getNameSpace } from '../utils';
+
+interface Store extends GlobalStore {
+  readonly test: {
+    readonly param: number;
+  };
+}
+
+const testAction = (state: Store) => (param: number) => ({
+  ...state,
+  param
+});
+
+const store: Store = {
+  test: {
+    param: 5
+  }
+};
+
+const dispatchedAction = {
+  actionName: 'testAction',
+  params: [1],
+  scopeName: 'test',
+  type: 'HELPER'
+};
+const dispatch = jest.fn();
+const actions: Modifiers<Store> = {
+  test: { testAction }
+};
 
 describe('utils', () => {
-  const store = {
-    test: {
-      param: 5
-    }
-  };
-  const testAction = ((state: GlobalStore, param: number) => ({...state, param })) as any
-  const dispatchedAction = {
-    scope: 'test',
-    action: 'testAction',
-    params: [1]
-  };
-
-  describe('createReducer', () => {
-    // TODO: Should rename it
-    const unboundActions = {
-      test: {
-        testAction: (store: GlobalStore) => (...args: any[]) => testAction(store, ...args)
-      }
-    } as UnBoundActions<GlobalStore>;
-
-    it('should trigger our action in a custom mapped reducer', () => {
-      const reducer = createReducer(unboundActions);
-      expect(reducer(store, dispatchedAction)).toStrictEqual(testAction(store, 1));
-    });
-  });
-
   describe('createDispatcher', () => {
-    const dispatch = jest.fn();
-    const actions = {
-      test: { testAction }
-    }
-
     it('should create an actions dispatcher from a reduced actions object', () => {
-      const actionDispatcher = createDispatcher(actions, dispatch);
-      const boundScope = bindScope('test', actions.test, dispatch);
+      const actionDispatcher = createDispatcher(store, actions, dispatch);
+      const boundScope = getNameSpace(store, 'test', actions.test, dispatch);
       const expectedDispatcherStructure = JSON.stringify({
         test: boundScope
       });
       // Check if kept the original structure
-      expect(JSON.stringify(actionDispatcher)).toStrictEqual(expectedDispatcherStructure);
+      expect(JSON.stringify(actionDispatcher)).toStrictEqual(
+        expectedDispatcherStructure
+      );
 
       // Check if the dispatcher was thriggered with the right action object
       actionDispatcher.test.testAction(...dispatchedAction.params);
-      expect(dispatch).toHaveBeenCalledWith(dispatchedAction);
+      expect(dispatch).toHaveBeenCalledWith({
+        ...dispatchedAction,
+        stateModifier: expect.any(Function)
+      });
     });
   });
 });

--- a/src/lib/contextManager.tsx
+++ b/src/lib/contextManager.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, Reducer, useReducer } from 'react';
+import React, { createContext } from 'react';
+import { useReducerAsync } from 'use-reducer-async';
 import { Actions, ContextObject, GlobalStore, UnBoundActions } from './types';
-import { createDispatcher, createReducer } from './utils';
+import { asyncActionHandlers, createDispatcher, reducer } from './utils';
 
 export const initContext = <
   GS extends GlobalStore,
@@ -30,11 +31,15 @@ const ContextProvider = <
   children
 }: ContextProviderProps<GS, UA>) => {
   const CTX = context;
-  const reducer = createReducer<GS, typeof actions>(actions);
   // TODO: Find typings to allow GS | Promise<GS> in reducer return type
-  const [state, dispatch] = useReducer<Reducer<GS, any>>(reducer as any, store);
+  const [state, dispatch] = useReducerAsync(
+    reducer,
+    store,
+    asyncActionHandlers
+  );
 
   const actionDispatcher = createDispatcher<GS, typeof actions>(
+    state,
     actions,
     dispatch
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,38 +4,57 @@ export interface GlobalStore {
   readonly [key: string]: any;
 }
 
+/*
+  Modifiers
+*/
+
 // (store) => (userid: number) => globalStore
-export type UnBoundAction<GS extends GlobalStore> = (
+export type Modifier<GS extends GlobalStore> = (
   store: GS
 ) => (...args: ReadonlyArray<any>) => GS | Promise<GS>;
+export interface UnBoundAction<GS extends GlobalStore> extends Modifier<GS> {}
 
-// (userid: number) => void
-export type BoundAction<GS extends GlobalStore, T extends UnBoundAction<GS>> = (
-  ...args: Parameters<ReturnType<T>>
-) => void;
-
-// { user: { add: UnBoundAction }}
-export interface UnBoundScope<GS extends GlobalStore> {
-  readonly [actionName: string]: UnBoundAction<GS>;
+// { add: Modifier, edit: Modifier, ... }
+export interface Scope<GS extends GlobalStore> {
+  readonly [actionName: string]: Modifier<GS>;
 }
+export interface UnBoundScope<GS extends GlobalStore> extends Scope<GS> {}
 
-// { user: { add: BoundAction }}
+// { user: Scope, auth: Scope, calendar: Scope ...}
+export interface Modifiers<GS extends GlobalStore> {
+  readonly [scope: string]: Scope<GS>;
+}
+export interface UnBoundActions<GS extends GlobalStore> extends Modifiers<GS> {}
+
+/*
+  Actions
+*/
+export type Action<GS extends GlobalStore, M extends Modifier<GS>> = (
+  ...args: Parameters<ReturnType<M>>
+) => void;
+// (userid: number) => void
+export interface BoundAction<
+  GS extends GlobalStore,
+  M extends UnBoundAction<GS>
+> extends Action<GS, M> {}
+
+// {{ add: Action, edit: Action, ... }}
+export type NameSpace<GS extends GlobalStore, S extends Scope<GS>> = {
+  readonly [A in keyof S]: Action<GS, S[A]>
+};
 export type BoundScope<GS extends GlobalStore, S extends UnBoundScope<GS>> = {
   readonly [A in keyof S]: BoundAction<GS, S[A]>
 };
 
-export interface UnBoundActions<GS extends GlobalStore> {
-  readonly [scope: string]: UnBoundScope<GS>;
-}
-
+// { user: NameSpace, auth: NameSpace, ...}
 export type Actions<GS extends GlobalStore, T extends UnBoundActions<GS>> = {
-  readonly [S in keyof T]: BoundScope<GS, T[S]>
+  readonly [S in keyof T]: NameSpace<GS, T[S]>
 };
 
 export interface ContextObject<
   GS extends GlobalStore,
-  UA extends UnBoundActions<GS>
+  M extends Modifiers<GS>
 > {
-  readonly actions: Context<Actions<GS, UA>>;
+  readonly actions: Context<Actions<GS, M>>;
   readonly store: Context<GS>;
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added use-reducer-async to allow async action calls


* **What is the current behavior?** (You can also link to an open issue here)
When you call to an async action, it replaces the store by a promise


* **What is the new behavior (if this is a feature change)?**
async actions works


* **Other information**:
Renaming Interfaces to be more consistent
A Modifier is a function that modifies the state
UnboundAction --> Modifier
UnboundScope --> Scope
UnboundActions --> Modifiers

An Action is a function (called by a component) that triggers a modifier
BoundAction --> Action
BoundScope --> NameSpace
Actions --> Actions